### PR TITLE
Fix for allowing list in wel perioddata for initial SP. 

### DIFF
--- a/mfsetup/sourcedata.py
+++ b/mfsetup/sourcedata.py
@@ -853,8 +853,9 @@ class TransientTabularSourceData(SourceData):
             # missing (period) keys default to 'mean';
             # 'none' to explicitly skip the stress period
             period_stat = self.period_stats.get(kper, current_stat)
-            if period_stat is not None and period_stat.lower() == 'none':
-                continue
+            if period_stat is not None and isinstance(period_stat, str):
+                if period_stat.lower() == 'none':
+                    continue
             aggregated = aggregate_dataframe_to_stress_period(df,
                                                               start_datetime=start,
                                                               end_datetime=end,


### PR DESCRIPTION
Thanks for the help with this Andy! Just checking for list type before checking for 'none' for initial stress period for wells