### PR TITLE
irregular boundary support for TMR inset CHDs

### DIFF
--- a/mfsetup/mf6model.py
+++ b/mfsetup/mf6model.py
@@ -93,6 +93,15 @@ class MF6model(MFsetupMixin, mf6.ModflowGwf):
         """Remake the idomain array from the source data,
         no data values in the top and bottom arrays, and
         so that cells above SFR reaches are inactive."""
+        
+        # first write out a copy of the layer 0 maximum idomsin footprint for potential use 
+        # to assign boundary conditions later
+        tmppath = os.path.join(self.cfg['simulation']['sim_ws'],
+                               'original',
+                               'idomain_max_extent.dat')
+        np.savetxt(tmppath, self.dis.idomain.array[0,:,:], fmt = '%d')
+        print('Writing maximum idomain footprint to: {}'.format(tmppath))
+        
         # loop thru LGR models and inactivate area of parent grid for each one
         lgr_idomain = np.ones(self.dis.idomain.array.shape, dtype=int)
         if isinstance(self.lgr, dict):

--- a/mfsetup/tmr.py
+++ b/mfsetup/tmr.py
@@ -602,11 +602,25 @@ class Tmr:
         if self.pi_list is None and self.pj_list is None:
             k, i, j = self.inset.get_boundary_cells(exclude_inactive=True)
         else:
-            k =[]
+            ktmp =[]
             for clay in range(self.inset.nlay):
-                k += list(clay*np.ones(len(self.pi_list)).astype(int))
-            i = self.inset.nlay * self.pi_list
-            j = self.inset.nlay * self.pj_list
+                ktmp += list(clay*np.ones(len(self.pi_list)).astype(int))
+            itmp = self.inset.nlay * self.pi_list
+            jtmp = self.inset.nlay * self.pj_list
+            
+            # get rid of cells that are inactive
+            wh = np.where(self.inset.dis.idomain.array >0)
+            activecells = set([(i,j,k) for i,j,k in zip(wh[0],wh[1],wh[2])])
+            chdcells = set([(kk,ii,jj) for ii,jj,kk in zip(itmp,jtmp,ktmp)])
+            active_chd_cells = set(chdcells).intersection(activecells)
+            
+            # unpack back to lists, then convert to numpy arrays
+            k,i,j = [],[],[]
+            for ccell in active_chd_cells:
+                ck,ci,cj = ccell
+                k.append(ck)
+                i.append(ci)
+                j.append(cj)
             k = np.array(k)
             i = np.array(i)
             j = np.array(j)


### PR DESCRIPTION
I followed your suggest @aleaf and used the `get_horizontal_connections` method in the `lakes.py` code to find edge cells. A couple caveats for now.

- code looks to see if a shapefile was supplied for idomain. If it was, and if CHDs are requested for the boundary, the edge cells in the inset model are found using the maximum footprint of idomain
- later, when idomain gets abbreviated due to thin cells, etc. any CHD cells in those locations are removed
- the previous behavior means where there are inactive cells at the boundary in a layer, there is no CHD for that edge in the domain. Assuming this is generally OK
- haven't tackled flux boundaries of MODFLOW models that are not MF6 yet