### PR TITLE
Fix ibound

### DIFF
--- a/mfsetup/discretization.py
+++ b/mfsetup/discretization.py
@@ -227,7 +227,7 @@ def fill_empty_layers(array):
 def fill_cells_vertically(top, botm):
     """In MODFLOW 6, cells where idomain != 1 are excluded from the solution.
     However, in the botm array, values are needed in overlying cells to
-    compute layer thickness (cells with idomain != 1 overlying cells with idomain == 1 need
+    compute layer thickness (cells with idomain != 1 overlying cells with idomain >= 1 need
     values in botm). Given a 3D numpy array with nan values indicating excluded cells,
     fill in the nans with the overlying values. For example, given the column of cells
     [10, nan, 8, nan, nan, 5, nan, nan, nan, 1], fill the nan values to make
@@ -514,7 +514,7 @@ def get_layer_thicknesses(top, botm, idomain=None):
     top = top.copy()
     botm = botm.copy()
     if idomain is not None:
-        idomain = idomain == 1
+        idomain = idomain >= 1
         top[~idomain[0]] = np.nan
         botm[~idomain] = np.nan
     all_layers = np.stack([top] + [b for b in botm])

--- a/mfsetup/mf6model.py
+++ b/mfsetup/mf6model.py
@@ -145,9 +145,9 @@ class MF6model(MFsetupMixin, mf6.ModflowGwf):
                                                      tol=1e-4)
         # include cells that are active in the existing idomain array
         # and cells inactivated on the basis of layer elevations
-        idomain = (self.dis.idomain.array == 1) & \
-                  (idomain_from_layer_elevations == 1) & \
-                  (lgr_idomain == 1)
+        idomain = (self.dis.idomain.array >= 1) & \
+                  (idomain_from_layer_elevations >= 1) & \
+                  (lgr_idomain >= 1)
         idomain = idomain.astype(int)
 
         # remove cells that conincide with lakes
@@ -328,8 +328,8 @@ class MF6model(MFsetupMixin, mf6.ModflowGwf):
             # unpack the cellids and get their respective ibound values
             k1, i1, j1 = zip(*exchangedf['cellidm1'])
             k2, i2, j2 = zip(*exchangedf['cellidm2'])
-            active1 = self.idomain[k1, i1, j1] == 1
-            active2 = inset_model.idomain[k2, i2, j2] == 1
+            active1 = self.idomain[k1, i1, j1] >= 1
+            active2 = inset_model.idomain[k2, i2, j2] >= 1
 
             # screen out connections involving an inactive cell
             active_connections = active1 & active2

--- a/mfsetup/mfmodel.py
+++ b/mfsetup/mfmodel.py
@@ -1320,10 +1320,10 @@ class MFsetupMixin():
 
         # create isfr array (where SFR cells will be populated)
         if self.version == 'mf6':
-            active_cells = np.sum(self.idomain == 1, axis=0) > 0
+            active_cells = np.sum(self.idomain >= 1, axis=0) > 0
             #active_cells = self.idomain.sum(axis=0) > 0
         else:
-            active_cells = np.sum(self.ibound == 1, axis=0) > 0
+            active_cells = np.sum(self.ibound >= 1, axis=0) > 0
             #active_cells = self.ibound.sum(axis=0) > 0
         # only include active cells that don't have another boundary condition
         # (besides the wel package)

--- a/mfsetup/mfnwtmodel.py
+++ b/mfsetup/mfnwtmodel.py
@@ -134,7 +134,7 @@ class MFnwtModel(MFsetupMixin, Modflow):
 
         # include cells that are active in the existing idomain array
         # and cells inactivated on the basis of layer elevations
-        ibound = (self.bas6.ibound.array > 0) & (ibound_from_layer_elevations == 1)
+        ibound = (self.bas6.ibound.array > 0) & (ibound_from_layer_elevations >= 1)
         ibound = ibound.astype(int)
 
         # remove cells that conincide with lakes

--- a/mfsetup/obs.py
+++ b/mfsetup/obs.py
@@ -169,7 +169,7 @@ def setup_head_observations(model, obs_info_files=None,
         df['yl'] = yl
         # drop observations located in inactive cels
         ibdn = model.bas6.ibound.array[df.klay.values, df.i.values, df.j.values]
-        active = ibdn == 1
+        active = ibdn >= 1
         df.drop(['i', 'j'], axis=1, inplace=True)
     elif format == 'obs':  # mf6 observation utility
         obstype = {'BAS': 'HEAD'}
@@ -179,7 +179,7 @@ def setup_head_observations(model, obs_info_files=None,
         df['id'] = list(zip(df.klay, df.i, df.j))
         # drop observations located in inactive cels
         idm = model.idomain[df.klay.values, df.i.values, df.j.values]
-        active = idm == 1
+        active = idm >= 1
         df.drop(['arr', 'intyp', 'i', 'j'], axis=1, inplace=True)
     df = df.loc[active].copy()
     return df

--- a/mfsetup/sourcedata.py
+++ b/mfsetup/sourcedata.py
@@ -283,7 +283,7 @@ class ArraySourceData(SourceData):
                  dest_model=None, source_modelgrid=None, source_array=None,
                  from_source_model_layers=None, datatype=None,
                  id_column=None, include_ids=None, column_mappings=None,
-                 resample_method='nearest',
+                 resample_method='linear',
                  vmin=-1e30, vmax=1e30, dtype=float,
                  multiplier=1.):
 

--- a/mfsetup/sourcedata.py
+++ b/mfsetup/sourcedata.py
@@ -506,7 +506,7 @@ class ArraySourceData(SourceData):
 
                     regridded = self.regrid_from_source_model(arr,
                                                               mask=mask,
-                                                              method='linear')
+                                                              method=self.resample_method)
 
                 assert regridded.shape == self.dest_modelgrid.shape[1:]
                 data[dest_k] = regridded * self.mult * self.unit_conversion

--- a/mfsetup/tests/test_lgr.py
+++ b/mfsetup/tests/test_lgr.py
@@ -102,7 +102,7 @@ def test_make_lgr_idomain(get_pleasant_lgr_parent_with_grid):
               (m.modelgrid.ycellcenters > b) & \
               (m.modelgrid.ycellcenters < t)
     assert idomain[:, isinset].sum() == 0
-    assert np.all(idomain[:, ~isinset] == 1)
+    assert np.all(idomain[:, ~isinset] >= 1)
 
 
 def test_lgr_grid_setup(get_pleasant_lgr_parent_with_grid):

--- a/mfsetup/tests/test_mf6_shellmound.py
+++ b/mfsetup/tests/test_mf6_shellmound.py
@@ -323,7 +323,7 @@ def test_dis_setup(shellmound_model_with_grid):
    # test that written idomain array reflects supplied shapefile of active area
     active_area = rasterize(m.cfg['dis']['source_data']['idomain']['filename'],
                             m.modelgrid)
-    isactive = active_area == 1
+    isactive = active_area >= 1
     written_idomain = load_array(m.cfg['dis']['griddata']['idomain'])
     assert np.all(written_idomain[:, ~isactive] <= 0)
 
@@ -354,8 +354,8 @@ def test_dis_setup(shellmound_model_with_grid):
     assert m.cfg['dis']['griddata']['top'] is not None
     assert m.cfg['dis']['griddata']['botm'] is not None
     dis = m.setup_dis()
-    assert np.array_equal(m.dis.botm.array[m.dis.idomain.array == 1],
-                          botm[m.dis.idomain.array == 1])
+    assert np.array_equal(m.dis.botm.array[m.dis.idomain.array >= 1],
+                          botm[m.dis.idomain.array >= 1])
 
     # test recreating just the top from the external array
     m.remove_package('dis')
@@ -363,8 +363,8 @@ def test_dis_setup(shellmound_model_with_grid):
     m.cfg['dis']['griddata']['botm'] = None
     dis = m.setup_dis()
     dis.write()
-    assert np.array_equal(m.dis.botm.array[m.dis.idomain.array == 1],
-                          botm[m.dis.idomain.array == 1])
+    assert np.array_equal(m.dis.botm.array[m.dis.idomain.array >= 1],
+                          botm[m.dis.idomain.array >= 1])
     arrayfiles = m.cfg['dis']['griddata']['top']
     for f in arrayfiles:
         assert os.path.exists(f['filename'])
@@ -375,7 +375,7 @@ def test_dis_setup(shellmound_model_with_grid):
     assert np.array_equal(m.dis.idomain.array, updated_idomain)
 
     # check that units were converted (or not)
-    assert np.allclose(dis.top.array[dis.idomain.array[0] == 1].mean(), 40, atol=10)
+    assert np.allclose(dis.top.array[dis.idomain.array[0] >= 1].mean(), 40, atol=10)
     mcaq = m.cfg['dis']['source_data']['botm']['filenames'][3]
     assert 'mcaq' in mcaq
     with rasterio.open(mcaq) as src:


### PR DESCRIPTION
- passing "nearest" interpolation method for ibound through to regridding from a parent model to avoid non-integer interpolated values
- refactor to consider all positive integers as active cells in MODFLOW models rather than only the integer 1