### PR TITLE
fix(sourcedata) expanding file extensions that are automatically

### DIFF
--- a/mfsetup/sourcedata.py
+++ b/mfsetup/sourcedata.py
@@ -412,7 +412,7 @@ class ArraySourceData(SourceData):
         elif isinstance(f, str):
             # sample "source_data" that may not be on same grid
             # TODO: add bilinear and zonal statistics methods
-            if f.endswith(".asc") or f.endswith(".tif"):
+            if any([f.lower().endswith(i) for i in ['asc','tif','tiff','geotiff', 'gtiff']]):
                 arr = get_values_at_points(f,
                                            self.dest_model.modelgrid.xcellcenters.ravel(),
                                            self.dest_model.modelgrid.ycellcenters.ravel(),


### PR DESCRIPTION
 assumed to be rasters to include 'tif','asc','tiff','geotiff','and 'gtiff'. evaluation casts filename to lower().

Some quick googling seems to show these are the most popular extensions for geotiffs.